### PR TITLE
throw error when invalid response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,18 +105,25 @@ export default class Nylas {
       this.serverBaseUrl +
       (opts?.exchangeCodeForTokenEndpoint ||
         DefaultEndpoints.exchangeCodeForToken);
-    const rawResp = await Request.post({
-      url,
-      body: {
-        token: authorizationCode,
-      },
-    });
-    const accessToken = await rawResp.text();
-    if (!accessToken || accessToken.length == 0) {
-      throw new Error('No access token was returned from the server.');
-    }
 
-    return accessToken;
+    try {
+      const rawResp = await Request.post({
+        url,
+        body: {
+          token: authorizationCode,
+        },
+      });
+
+      const accessToken = await rawResp.text();
+
+      if (!accessToken || accessToken.length == 0) {
+        throw new Error('No access token was returned from the server.');
+      }
+
+      return accessToken;
+    } catch (err) {
+      throw new Error(err);
+    }
   };
 
   /**


### PR DESCRIPTION
# Description
<!-- Add information about what your PR achieves -->
If there is an invalid `code` passed to the sdk, getting the body payload will fail so these changes allow the sdk to fail gracefully.
```
 const accessToken = await rawResp.text();
```

@mrashed-dev first time contributing so let me know your thoughts!

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.