### PR TITLE
docs: archived notice + redirect to @nylas/connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
+> [!CAUTION]
+> 🛑 **This repository is archived and no longer maintained.**
+>
+> This is the legacy browser/JavaScript SDK (`@nylas/nylas-js`), built for the Nylas v2 API. Do not use it for new projects — use [`@nylas/connect`](https://github.com/nylas/javascript) for the v3 API, and see current Nylas resources below.
+
 <div align="center">
   <a href="https://www.nylas.com/">
     <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
   </a>
 
   <h1>Nylas JavaScript SDK (legacy)</h1>
+
+  <p><img src="https://img.shields.io/badge/Status-Archived-critical?style=for-the-badge" alt="Status: Archived" /></p>
 </div>
 
 <br />
-
-> ## ⚠️ This repository is archived and no longer maintained
->
-> This is the legacy browser/JavaScript SDK (`@nylas/nylas-js`), built for the Nylas v2 API. It is no longer developed or supported.
->
-> **For new projects, use [`@nylas/connect`](https://github.com/nylas/javascript)** — the modern, maintained Nylas JavaScript/TypeScript packages (OAuth connection library + React components) for the v3 API.
 
 ## Where to go now
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,21 @@
-<a href="https://www.nylas.com/">
-    <img src="https://brand.nylas.com/assets/downloads/logo_horizontal_png/Nylas-Logo-Horizontal-Blue_.png" alt="Aimeos logo" title="Aimeos" align="right" height="60" />
-</a>
+<div align="center">
+  <a href="https://www.nylas.com/">
+    <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
+  </a>
 
-# Nylas JavaScript SDK
+  <h1>Nylas JavaScript SDK (legacy)</h1>
+</div>
 
-![npm](https://img.shields.io/npm/v/@nylas/nylas-js)
+<br />
 
-This is the GitHub repository for the Nylas JavaScript SDK. The Nylas Communications Platform provides REST APIs for [Email](https://developer.nylas.com/docs/connectivity/email/), [Calendar](https://developer.nylas.com/docs/connectivity/calendar/), and [Contacts](https://developer.nylas.com/docs/connectivity/contacts/), and the Nylas Javascript SDK is the quickest way to build your integration using JavaScript.
+> ## ⚠️ This repository is archived and no longer maintained
+>
+> This is the legacy browser/JavaScript SDK (`@nylas/nylas-js`), built for the Nylas v2 API. It is no longer developed or supported.
+>
+> **For new projects, use [`@nylas/connect`](https://github.com/nylas/javascript)** — the modern, maintained Nylas JavaScript/TypeScript packages (OAuth connection library + React components) for the v3 API.
 
-Here are some resources to help you get started:
+## Where to go now
 
-- [Quickstart](https://developer.nylas.com/docs/the-basics/quickstart/)
-- [Nylas API Reference](https://developer.nylas.com/docs/api/)
-
-
-## ⚙️ Install
-
-To install the Nylas JavaScript SDK, you will first need to have [npm](https://www.npmjs.com/get-npm) installed on your machine.
-
-Then, head to the nearest command line and run the following:
-```bash
-npm install @nylas/nylas-js
-```
-
-To install this package from source, clone this repo and run `npm install` from inside the project directory:
-
-```bash
-git clone https://github.com/nylas/nylas-js.git
-cd nylas-js
-npm install
-```
-
-## ⚡️ Usage
-
-The entrypoint for the SDK is `Nylas`, which can be imported as an ES module and instantiated:
-
-```javascript
-import Nylas from 'nylas-js'
-
-const nylas = new Nylas({
-  // Config
-});
-```
-
-### Configuration options
-These are the following options that can be passed in to configure an instance of the Nylas JS SDK
-
-#### `serverBaseUrl`
-The URL of the backend server configured with the Nylas middleware or Nylas routes implemented.
-
-## 💙 Contributing
-
-Interested in contributing to the Nylas JavaScript SDK project? Thanks so much for your interest! We are always looking for improvements to the project and contributions from open-source developers are greatly appreciated.
-
-Please refer to [Contributing](Contributing.md) for information about how to make contributions to this project. We welcome questions, bug reports, and pull requests.
-
-## 📝 License
-
-This project is licensed under the terms of the MIT license. Please refer to [LICENSE](LICENSE.txt) for the full terms. 
-
-
+- 📦 [`nylas/javascript`](https://github.com/nylas/javascript) — `@nylas/connect` and `@nylas/react`
+- 📖 [Developer documentation](https://developer.nylas.com/)
+- 🚀 [Sign up for free](https://dashboard-v3.nylas.com/register)


### PR DESCRIPTION
Replaces the README with a concise archived notice that redirects visitors to current Nylas resources. Intended as the 'merge, then archive' step. All links verified (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)